### PR TITLE
Handle carriage returns

### DIFF
--- a/examples/Procfile-countdown
+++ b/examples/Procfile-countdown
@@ -1,0 +1,1 @@
+countdown: while true; do printf '%s\r' "$(date)"; sleep 1; done

--- a/spec/nox/intercepting_io_spec.cr
+++ b/spec/nox/intercepting_io_spec.cr
@@ -34,4 +34,13 @@ Spectator.describe Nox::InterceptingIO do
     expect(output).to contain("foo".colorize(:cyan).to_s)
     expect(output).to contain("bar".colorize(:yellow).to_s)
   end
+
+  it "handles carriage returns" do
+    wrapped = IO::Memory.new
+    intercepting_io = Nox::InterceptingIO.new(wrapped, "foo")
+
+    intercepting_io.print("line 1 - 1%\rline 1 - 2%")
+
+    expect(decolorize(wrapped.to_s)).to eq("foo | line 1 - 1%\rfoo | line 1 - 2%\n")
+  end
 end

--- a/spec/nox/process_spec.cr
+++ b/spec/nox/process_spec.cr
@@ -14,6 +14,7 @@ Spectator.describe Nox::Process do
 
     expect(output.shift).to match(/web | Starting with pid of \d+/)
     expect(output.shift).to eq("web | hello")
+    expect(output.shift).to eq("web | ")
     expect(output.shift).to eq("web | Done")
   end
 

--- a/spec/nox/process_spec.cr
+++ b/spec/nox/process_spec.cr
@@ -14,7 +14,6 @@ Spectator.describe Nox::Process do
 
     expect(output.shift).to match(/web | Starting with pid of \d+/)
     expect(output.shift).to eq("web | hello")
-    expect(output.shift).to eq("web | ")
     expect(output.shift).to eq("web | Done")
   end
 

--- a/src/nox/intercepting_io.cr
+++ b/src/nox/intercepting_io.cr
@@ -30,14 +30,17 @@ class Nox::InterceptingIO < IO
 
   def write(slice : Bytes) : Nil
     String.build(&.write(slice))
-      .lines
+      .split(/(?<=[\n\r])/)
       .each do |line|
         result = String.build do |str|
           str << @name.ljust(max_name_size + 1).sub(@name, @name.colorize(@color).to_s)
           str << "| "
           str << line
+          if !line.ends_with?(/[\n\r]/)
+            str << "\n"
+          end
         end
-        @wrapped.puts(result.chomp)
+        @wrapped.print(result)
       end
   end
 

--- a/src/nox/intercepting_io.cr
+++ b/src/nox/intercepting_io.cr
@@ -39,7 +39,6 @@ class Nox::InterceptingIO < IO
         if !line.ends_with?(/[\n\r]/)
           str << "\n"
         end
-
       end
       @wrapped.print(result)
     end

--- a/src/nox/intercepting_io.cr
+++ b/src/nox/intercepting_io.cr
@@ -29,19 +29,20 @@ class Nox::InterceptingIO < IO
   end
 
   def write(slice : Bytes) : Nil
-    String.build(&.write(slice))
-      .split(/(?<=[\n\r])/)
-      .each do |line|
-        result = String.build do |str|
-          str << @name.ljust(max_name_size + 1).sub(@name, @name.colorize(@color).to_s)
-          str << "| "
-          str << line
-          if !line.ends_with?(/[\n\r]/)
-            str << "\n"
-          end
+    lines = String.build(&.write(slice)).split(/(?<=[\n\r])/)
+    lines.pop if lines.last.blank?
+    lines.each do |line|
+      result = String.build do |str|
+        str << @name.ljust(max_name_size + 1).sub(@name, @name.colorize(@color).to_s)
+        str << "| "
+        str << line
+        if !line.ends_with?(/[\n\r]/)
+          str << "\n"
         end
-        @wrapped.print(result)
+
       end
+      @wrapped.print(result)
+    end
   end
 
   private def max_name_size : Int32


### PR DESCRIPTION
Fixes https://github.com/matthewmcgarvey/nox/issues/2

Includes line splitting on carriage returns and maintains the carriage return ending.